### PR TITLE
use opening time when no time is passed on request.

### DIFF
--- a/src/Filters/DateFiltersTrait.php
+++ b/src/Filters/DateFiltersTrait.php
@@ -44,18 +44,24 @@ trait DateFiltersTrait
         return $this->builder->$whereMethod(DB::raw("dayofweek(" . $this->rawDateField() . ")"), $dayofweek);
     }
 
-    public function start_time($time = "00:00")
+    public function start_time($time = null)
     {
         if (! $this->dateField) {
             return $this->builder;
         }
+        if ($time == null) {
+            return $this->builder->whereRaw("{$this->rawDateField()} > '{$this->openingTime}'");
+        }
         return $this->builder->whereRaw("TIME(DATE_ADD(" . $this->rawDateField() . ", INTERVAL {$this->offsetHours} HOUR)) > '{$time}'");
     }
 
-    public function end_time($time = "23:59")
+    public function end_time($time = null)
     {
         if (! $this->dateField) {
             return $this->builder;
+        }
+        if ($time == null) {
+            return $this->builder->whereRaw("{$this->rawDateField()} > '{$this->openingTime}'");
         }
         return $this->builder->whereRaw("TIME(DATE_ADD(" . $this->rawDateField() . ", INTERVAL {$this->offsetHours} HOUR)) < '{$time}'");
     }

--- a/src/Filters/DateFiltersTrait.php
+++ b/src/Filters/DateFiltersTrait.php
@@ -46,22 +46,16 @@ trait DateFiltersTrait
 
     public function start_time($time = null)
     {
-        if (! $this->dateField) {
+        if (! $this->dateField || ! $time) {
             return $this->builder;
-        }
-        if ($time == null) {
-            return $this->builder->whereRaw("{$this->rawDateField()} > '{$this->openingTime}'");
         }
         return $this->builder->whereRaw("TIME(DATE_ADD(" . $this->rawDateField() . ", INTERVAL {$this->offsetHours} HOUR)) > '{$time}'");
     }
 
     public function end_time($time = null)
     {
-        if (! $this->dateField) {
+        if (! $this->dateField || ! $time) {
             return $this->builder;
-        }
-        if ($time == null) {
-            return $this->builder->whereRaw("{$this->rawDateField()} > '{$this->openingTime}'");
         }
         return $this->builder->whereRaw("TIME(DATE_ADD(" . $this->rawDateField() . ", INTERVAL {$this->offsetHours} HOUR)) < '{$time}'");
     }


### PR DESCRIPTION
Fixes https://bitbucket.org/revo-pos/revo-back/issues/476/start_time-and-end_time-does-not-work

Should be:

`$time = $time ? : $this->openingTime`

But openingTime is not in GMT so we must not substract offsetHours