### PR TITLE
XSS control when getValue. No htmlentities when comes from csv and xls exportation.

### DIFF
--- a/src/Exporters/CsvExporter.php
+++ b/src/Exporters/CsvExporter.php
@@ -85,7 +85,7 @@ class CsvExporter extends BaseExporter
     private function writeRow($row)
     {
         foreach ($this->getExportFields() as $field) {
-            $this->output .= $field->getValue($row) . ';';
+            $this->output .= $field->getValue($row, false) . ';';
         }
         $this->output .= PHP_EOL;
     }

--- a/src/Exporters/Field/ExportField.php
+++ b/src/Exporters/Field/ExportField.php
@@ -90,13 +90,13 @@ class ExportField
         return $this->title ? : $this->field;
     }
 
-    public function getValue($row)
+    public function getValue($row, $protectionXSS = true)
     {
         if(is_array($this->transformation)){
             return $this->transformMany($row);
         }
         $fieldData = data_get($row,$this->field);
-        if (is_string($fieldData)){
+        if ($protectionXSS && is_string($fieldData)){
             $fieldData = htmlentities($fieldData);
         }
         return app(ReportDataTransformer::class)::transform($row, $this->field, $fieldData, $this->transformation, $this->transformationData);

--- a/src/Exports/BaseExport.php
+++ b/src/Exports/BaseExport.php
@@ -50,12 +50,12 @@ class BaseExport implements WithTitle, WithMapping, FromQuery, WithHeadings, Wit
     {
         return $this->mapping->map(function ($exportField) use ($product) {
             if ($exportField->isPercentage()) {
-                return $this->stringToFloat($exportField->getValue($product)) / 100.0;
+                return $this->stringToFloat($exportField->getValue($product, false)) / 100.0;
             }
             if ($exportField->isNumeric()) {
-                return $this->stringToFloat($exportField->getValue($product));
+                return $this->stringToFloat($exportField->getValue($product, false));
             }
-            return $exportField->getValue($product);
+            return $exportField->getValue($product, false);
         })->toArray();
     }
 


### PR DESCRIPTION
Linear: https://linear.app/revo/issue/REV-4400/xss-control-protection-not-for-export-csv-and-xls

reviewer @PauBenetPrat 